### PR TITLE
Updated requirements, and fix issues with pydantic validator and attributes.

### DIFF
--- a/code/modelling/CVnn.py
+++ b/code/modelling/CVnn.py
@@ -9,7 +9,7 @@ import copy
 from collections import namedtuple
 from collections.abc import KeysView
 from typing import Callable, List, Tuple, Optional, Union
-from pydantic import BaseModel, ValidationError, validator, root_validator
+from pydantic import BaseModel, ValidationError, validator, model_validator
 
 import torch
 
@@ -210,14 +210,15 @@ class CVnnRecipe(modelfactory.Recipe_base):
 	linear: LinearLayers = LinearLayers.kSplitLinear
 	init: Callable 	 	 = cplx_trabelsi_standard_
 	probtype: ProbabilityKind = ProbabilityKind.kReal	#real or complex probability
-	mlp_config = kCVnnMLPrecipe 	# = [(5 * 5 * 50, 500), (500, 10), (20, 10)]
+	mlp_config: CVnnMLPrecipe = kCVnnMLPrecipe 	# = [(5 * 5 * 50, 500), (500, 10), (20, 10)]
 	activation: Activations = Activations.kReLU
 	colorspace: Colorspaces = Colorspaces.grayscale
 	name: Optional[str] = None
-	@root_validator
+	@model_validator(mode='after')
 	@classmethod
 	def check_settings(cls, values):
-		if (not values.get('init') in kInitFuncs):
+		init_function = getattr(values, 'init', None)
+		if init_function not in kInitFuncs:
 			raise(InitFuncError(f"{values.get('init').__name__} is not a valid func."))
 		return values
 

--- a/code/modelling/CVnn.py
+++ b/code/modelling/CVnn.py
@@ -203,7 +203,7 @@ class CVnnRecipe(modelfactory.Recipe_base):
 	"""
 	modeltype: SupportedModels = SupportedModels.kCoShCVNN
 	conv2d: ConvLayers	 = ConvLayers.kSplitConv		#defaults to Ivan's 
-	conv_config: List[tuple] = [
+	conv_config: List[Union[CVnn_base.Conv2dDesc, CVnn_base.AvgPool2dDesc]] = [
 								CVnn_base.Conv2dDesc(20, 30, 5, 1), CVnn_base.AvgPool2dDesc(2,2),
 								CVnn_base.Conv2dDesc(30, 50, 5, 1), CVnn_base.AvgPool2dDesc(2,2)
 					]

--- a/code/modelling/SplitCVnn.py
+++ b/code/modelling/SplitCVnn.py
@@ -205,7 +205,7 @@ class CoShCVNN(CVnn_base.CVnn_Base):
 			if dropout > 0.0:
 				layer_dict[f"dropout-conv{i}"] = cplxnn.modules.extra.CplxDropout(dropout)
 		else:
-			raise Exception(f"Description of {type(shape)=} is not supported. Supported types include ({CVnn_Base.Conv2dDesc}, {CVnn_Base.AvgPool2dDesc}).")
+			raise Exception(f"Description of {type(shape)=} is not supported. Supported types include ({CVnn_base.Conv2dDesc}, {CVnn_base.AvgPool2dDesc}).")
 		return layer_dict
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest
 ./libs/tt-pytorch
 ./libs/shnetutil
 scipy
-sklearn
+scikit-learn
 scikit-image
 joblib
 numba

--- a/setup.txt
+++ b/setup.txt
@@ -3,9 +3,9 @@ Python 3.8.5
 
 1. python -m pip install --upgrade pip.
 2. python -m venv venv4coshnet
-3. activate venv4shearlets
-   mac/linux: source venv4shearlets/bin/activate
-   win10: venv4shearlets\Scripts\activate
+3. activate venv4coshnet
+   mac/linux: source venv4coshnet/bin/activate
+   win10: venv4coshnet\Scripts\activate
 Note: it is very important to locate venv directly under `root`. Some path logic relies on it.
 
 4. pip install wheel (should be part of Miniconda 3.8x if on win10)


### PR DESCRIPTION
sklearn is deprecated and changed to scikit-learn.

I had some issues trying to run the command "python test_fashion.py --help". It turned out root_validator is deprecated, so I updated it to @model_validator(mode='after'), to be called after the model's standard validation.

updated mlp_config to be represented as a field because I was having pydantic.errors.

Lastly, I fixed attribute issues in the CVnnRecipe object.

Sorry for the long update, first PR ever.